### PR TITLE
always provide a valid view to mask in likelihood

### DIFF
--- a/neurosym/program_dist/tree_distribution/ordering.py
+++ b/neurosym/program_dist/tree_distribution/ordering.py
@@ -2,6 +2,8 @@ from abc import ABC, abstractmethod
 from types import NoneType
 from typing import Dict, List, Union
 
+import numpy as np
+
 
 class NodeOrdering(ABC):
     """
@@ -20,6 +22,9 @@ class NodeOrdering(ABC):
         """
         Orders the subnodes of the node with the given symbol index.
         """
+        assert isinstance(
+            root_sym_idx, (int, np.int32, np.int64)
+        ), f"Expected int, got {root_sym_idx} of type {type(root_sym_idx)}"
         order = self.compute_order(root_sym_idx)
         if order is None:
             return range(n_subnodes)

--- a/neurosym/program_dist/tree_distribution/tree_dist_likelihood_computer.py
+++ b/neurosym/program_dist/tree_distribution/tree_dist_likelihood_computer.py
@@ -45,6 +45,8 @@ def compute_likelihood(
             preorder_mask=preorder_mask,
             tracker=tracker,
         )
+        if likelihood == -float("inf"):
+            break
     preorder_mask.on_exit(start_position, top_symbol)
     return likelihood
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="neurosym",
-    version="0.0.30",
+    version="0.0.31",
     author="Kavi Gupta, Atharva Sehgal, Maddy Bowers",
     author_email="kavig+neurosym@mit.edu",
     description="Neurosymbolic library.",

--- a/tests/program_dist/bigram_test.py
+++ b/tests/program_dist/bigram_test.py
@@ -7,7 +7,7 @@ import torch
 import neurosym as ns
 from tests.utils import assertDSL
 
-from .utils import ChildrenInOrderMask, ProbabilityTester
+from .utils import ChildrenInOrderAsserterMask, ChildrenInOrderMask, ProbabilityTester
 
 
 def get_dsl(with_vars=False):
@@ -39,6 +39,9 @@ fam_with_vars = ns.BigramProgramDistributionFamily(dsl_with_vars)
 dsl_for_ordering = get_dsl_for_ordering()
 fam_with_ordering = ns.BigramProgramDistributionFamily(
     dsl_for_ordering, additional_preorder_masks=[ChildrenInOrderMask]
+)
+fam_with_ordering_asserted = ns.BigramProgramDistributionFamily(
+    dsl_for_ordering, additional_preorder_masks=[ChildrenInOrderAsserterMask]
 )
 fam_with_ordering_231 = ns.BigramProgramDistributionFamily(
     dsl_for_ordering,
@@ -524,6 +527,23 @@ class BigramLikelihoodTest(unittest.TestCase):
             "(+ (2) (3) (1))",
             "log(0)",
             family=fam_with_ordering,
+        )
+
+    def test_ordered_asserting(self):
+        self.assertLikelihood(
+            fam_with_ordering_asserted.uniform(),
+            "(+ (1) (2) (3))",
+            "log(1/27)",
+            family=fam_with_ordering_asserted,
+        )
+        # distribution where 1 is not allowed
+        dist = fam_with_ordering_asserted.uniform()
+        dist.distribution[:, :, 2] = 0
+        self.assertLikelihood(
+            dist,
+            "(+ (1) (2) (3))",
+            "log(0)",
+            family=fam_with_ordering_asserted,
         )
 
     def test_ordered_231(self):

--- a/tests/program_dist/utils.py
+++ b/tests/program_dist/utils.py
@@ -53,3 +53,27 @@ class ChildrenInOrderMask(ns.PreorderMask):
 
     def on_exit(self, position, symbol):
         pass
+
+
+class ChildrenInOrderAsserterMask(ns.PreorderMask):
+    def __init__(self, tree_dist, dsl):
+        del dsl
+        super().__init__(tree_dist)
+        self.proper_context = False
+        self.seen_symbols = []
+
+    def compute_mask(self, position, symbols):
+        return [True] * len(symbols)
+
+    def on_entry(self, position, symbol):
+        symbol = self.tree_dist.symbols[symbol][0]
+        if self.proper_context:
+            self.seen_symbols.append(symbol)
+            assert int(symbol) == len(
+                self.seen_symbols
+            ), f"Expected {len(self.seen_symbols)}, got {symbol}"
+        if symbol == "+":
+            self.proper_context = True
+
+    def on_exit(self, position, symbol):
+        pass


### PR DESCRIPTION
do not provide an invariant breaking series of steps to the preorder mask for programs matching the invariant. specifically, before, if you had something like `(+ (1) (2) (3))` and `(1)` has a likelihood of -inf, but `(2)` and `(3)` has a non-neg-inf likelihood, then the mask would have seen the sequence

enter +
enter 2
exit 2
enter 3
exit 3

which is inaccurate.

Now it would receive the sequence

enter +

which is valid