### PR TITLE
fix issue with the cache not being used in certain recursion contexts

### DIFF
--- a/neurosym/program_dist/tree_distribution/tree_dist_enumerator.py
+++ b/neurosym/program_dist/tree_distribution/tree_dist_enumerator.py
@@ -52,7 +52,7 @@ def enumerate_tree_dist(
         preorder_mask = tree_dist.mask_constructor(tree_dist)
         cache = {} if use_cache and preorder_mask.can_cache else None
         preorder_mask.on_entry(0, 0)
-        for program, likelihood in _enumerate_tree_dist_dfs(
+        for program, likelihood in _enumerate_tree_dist_dfs_uncached(
             tree_dist, likelihood_bound, ((0, 0),), preorder_mask, cache
         ):
             if (


### PR DESCRIPTION
Test: `pytest tests/program_dist/bigram_test.py::BigramEnumerationTest::test_enumeration_more_complex_get_even_more_even_more`

Before: 21.56s
After: 19.99s

-7.2% time usage.