### PR TITLE
Multiprocessing datasets

### DIFF
--- a/neurosym/datasets/load_data.py
+++ b/neurosym/datasets/load_data.py
@@ -1,6 +1,6 @@
 import io
-from multiprocessing import get_context
 import os
+from multiprocessing import get_context
 from typing import Callable
 
 import numpy as np
@@ -129,9 +129,9 @@ class DatasetWrapper(pl.LightningDataModule):
             batch_size=self.batch_size,
             num_workers=self.num_workers,
             pin_memory=(self.num_workers > 0),
-            multiprocessing_context=get_context("loky")
-            if (self.num_workers > 0)
-            else None,
+            multiprocessing_context=(
+                get_context("loky") if (self.num_workers > 0) else None
+            ),
         )
 
     def val_dataloader(self):
@@ -140,9 +140,9 @@ class DatasetWrapper(pl.LightningDataModule):
             batch_size=self.batch_size,
             num_workers=self.num_workers,
             pin_memory=(self.num_workers > 0),
-            multiprocessing_context=get_context("loky")
-            if (self.num_workers > 0)
-            else None,
+            multiprocessing_context=(
+                get_context("loky") if (self.num_workers > 0) else None
+            ),
         )
 
     def test_dataloader(self):
@@ -151,9 +151,9 @@ class DatasetWrapper(pl.LightningDataModule):
             batch_size=self.batch_size,
             num_workers=self.num_workers,
             pin_memory=(self.num_workers > 0),
-            multiprocessing_context=get_context("loky")
-            if (self.num_workers > 0)
-            else None,
+            multiprocessing_context=(
+                get_context("loky") if (self.num_workers > 0) else None
+            ),
         )
 
 
@@ -187,5 +187,5 @@ def numpy_dataset_from_github(
             _get_raw_url(github_url, test_output_path),
             None,
         ),
-        **kwargs
+        **kwargs,
     )

--- a/neurosym/datasets/load_data.py
+++ b/neurosym/datasets/load_data.py
@@ -1,4 +1,5 @@
 import io
+from multiprocessing import get_context
 import os
 from typing import Callable
 
@@ -114,20 +115,46 @@ class DatasetWrapper(pl.LightningDataModule):
         train: torch.utils.data.Dataset,
         test: torch.utils.data.Dataset,
         batch_size: int = 32,
+        num_workers: int = 0,
     ):
         super().__init__()
         self.train = train
         self.test = test
         self.batch_size = batch_size
+        self.num_workers = num_workers
 
     def train_dataloader(self):
-        return torch.utils.data.DataLoader(self.train, batch_size=self.batch_size)
+        return torch.utils.data.DataLoader(
+            self.train,
+            batch_size=self.batch_size,
+            num_workers=self.num_workers,
+            pin_memory=(self.num_workers > 0),
+            multiprocessing_context=get_context("loky")
+            if (self.num_workers > 0)
+            else None,
+        )
 
     def val_dataloader(self):
-        return torch.utils.data.DataLoader(self.test, batch_size=self.batch_size)
+        return torch.utils.data.DataLoader(
+            self.test,
+            batch_size=self.batch_size,
+            num_workers=self.num_workers,
+            pin_memory=(self.num_workers > 0),
+            multiprocessing_context=get_context("loky")
+            if (self.num_workers > 0)
+            else None,
+        )
 
     def test_dataloader(self):
-        return torch.utils.data.DataLoader(self.test, batch_size=self.batch_size)
+        return torch.utils.data.DataLoader(
+            self.test,
+            batch_size=self.batch_size,
+            num_workers=self.num_workers,
+            pin_memory=(self.num_workers > 0),
+            multiprocessing_context=get_context("loky")
+            if (self.num_workers > 0)
+            else None,
+        )
 
 
 def numpy_dataset_from_github(
@@ -136,6 +163,7 @@ def numpy_dataset_from_github(
     train_output_path: str,
     test_input_path: str,
     test_output_path: str,
+    **kwargs,
 ) -> Callable[[int], DatasetWrapper]:
     """
     Load a dataset from a github url.
@@ -159,4 +187,5 @@ def numpy_dataset_from_github(
             _get_raw_url(github_url, test_output_path),
             None,
         ),
+        **kwargs
     )

--- a/neurosym/datasets/near_data_example.py
+++ b/neurosym/datasets/near_data_example.py
@@ -1,7 +1,7 @@
 from .load_data import DatasetWrapper, numpy_dataset_from_github
 
 
-def near_data_example(train_seed) -> DatasetWrapper:
+def near_data_example(train_seed, **kwargs) -> DatasetWrapper:
     """
     Data example from the Near library. Imported from Github.
     Takes a seed and returns a DatasetWrapper object containing the data.
@@ -13,4 +13,5 @@ def near_data_example(train_seed) -> DatasetWrapper:
         "train_ex_labels.npy",
         "test_ex_data.npy",
         "test_ex_labels.npy",
+        **kwargs
     )(train_seed)

--- a/neurosym/utils/imports.py
+++ b/neurosym/utils/imports.py
@@ -14,5 +14,7 @@ def import_pytorch_lightning():
     warnings.filterwarnings("ignore", ".*does not have many workers.*")
     warnings.filterwarnings("ignore", ".*GPU available but not used.*")
     logger = logging.getLogger("pytorch_lightning.utilities.rank_zero")
-    logger.setLevel(logging.ERROR)
+    logger.setLevel(logging.WARNING)
+    logger = logging.getLogger("pytorch_lightning.accelerators.cuda")
+    logger.setLevel(logging.WARNING)
     return pl

--- a/tests/near/test_async_search.py
+++ b/tests/near/test_async_search.py
@@ -22,7 +22,7 @@ class TestNEARAsyncSearch(unittest.TestCase):
         This tests an async version of bounded_astar search.
         """
         # pylint: disable=duplicate-code
-        datamodule = ns.datasets.near_data_example(train_seed=0)
+        datamodule = ns.datasets.near_data_example(train_seed=0, batch_size=32, num_workers=0)
         input_dim, output_dim = datamodule.train.get_io_dims()
         original_dsl = near.example_rnn_dsl(input_dim, output_dim)
         trainer_cfg = near.NEARTrainerConfig(
@@ -75,6 +75,7 @@ class TestNEARAsyncSearch(unittest.TestCase):
                 ),
                 max_depth=3,
                 max_workers=4,
+                depth_computer=near.ProbableDepthComputer()
             )
             while True:
                 print("iteration: ", n_iter)

--- a/tests/near/test_async_search.py
+++ b/tests/near/test_async_search.py
@@ -22,7 +22,9 @@ class TestNEARAsyncSearch(unittest.TestCase):
         This tests an async version of bounded_astar search.
         """
         # pylint: disable=duplicate-code
-        datamodule = ns.datasets.near_data_example(train_seed=0, batch_size=32, num_workers=0)
+        datamodule = ns.datasets.near_data_example(
+            train_seed=0, batch_size=32, num_workers=0
+        )
         input_dim, output_dim = datamodule.train.get_io_dims()
         original_dsl = near.example_rnn_dsl(input_dim, output_dim)
         trainer_cfg = near.NEARTrainerConfig(
@@ -75,7 +77,7 @@ class TestNEARAsyncSearch(unittest.TestCase):
                 ),
                 max_depth=3,
                 max_workers=4,
-                depth_computer=near.ProbableDepthComputer()
+                depth_computer=near.ProbableDepthComputer(),
             )
             while True:
                 print("iteration: ", n_iter)

--- a/tests/near/test_sequential_dsl.py
+++ b/tests/near/test_sequential_dsl.py
@@ -81,6 +81,7 @@ class TestNEARSequentialDSL(unittest.TestCase):
                     datamodule=datamodule,
                 ),
                 max_depth=3,
+                depth_computer=near.ProbableDepthComputer(),
             )
             while True:
                 print("iteration: ", n_iter)

--- a/tests/near/test_simple_dsl.py
+++ b/tests/near/test_simple_dsl.py
@@ -88,7 +88,13 @@ class TestNEARSimpleDSL(unittest.TestCase):
                 return len(str(x.program.children[0]))
             return 0
 
-        node = next(ns.search.bounded_astar(g, cost, max_depth=7)).program
+        node = next(
+            ns.search.bounded_astar(
+                g,
+                cost,
+                max_depth=7,
+            )
+        ).program
         self.assertEqual(node.children[0], ns.SExpression(symbol="ones", children=()))
 
     def test_simple_dsl_enumerate(self):


### PR DESCRIPTION
Allow multiple workers for larger datasets.
With `num_workers=0` this retains the original behavior.