### PR TITLE
add generic mlp/rnn

### DIFF
--- a/docs/source/near.rst
+++ b/docs/source/near.rst
@@ -31,6 +31,7 @@ NEAR Factory Functions
 .. autoclass:: neurosym.examples.near.DictionaryNeuralHoleFiller
 .. autoclass:: neurosym.examples.near.DoNothingNeuralHoleFiller
 .. autoclass:: neurosym.examples.near.UnionNeuralHoleFiller
+.. autoclass:: neurosym.examples.near.GenericMLPRNNNeuralHoleFiller
 .. autofunction:: neurosym.examples.near.create_modules
 .. autofunction:: neurosym.examples.near.mlp_factory
 .. autoclass:: neurosym.examples.near.MLPConfig

--- a/neurosym/examples/near/__init__.py
+++ b/neurosym/examples/near/__init__.py
@@ -1,4 +1,5 @@
 from neurosym.examples.near.methods.base_trainer import BaseTrainer, BaseTrainerConfig
+from neurosym.examples.near.models.generic_mlp_rnn import GenericMLPRNNNeuralHoleFiller
 from neurosym.examples.near.validation import (
     UninitializableProgramError,
     ValidationCost,

--- a/neurosym/examples/near/models/generic_mlp_rnn.py
+++ b/neurosym/examples/near/models/generic_mlp_rnn.py
@@ -1,0 +1,142 @@
+from math import prod
+from typing import Tuple
+
+import torch.nn as nn
+
+from neurosym.examples.near.models.mlp import MLP, MLPConfig
+from neurosym.examples.near.models.rnn import RNNConfig, Seq2ClassRNN, Seq2SeqRNN
+from neurosym.examples.near.neural_hole_filler import NeuralHoleFiller
+from neurosym.types.type import ArrowType, ListType, TensorType
+from neurosym.types.type_annotated_object import TypeAnnotatedObject
+from neurosym.types.type_shape import infer_output_shape
+from neurosym.types.type_string_repr import render_type
+from neurosym.types.type_with_environment import TypeWithEnvironment
+
+
+def _classify_type(typ):
+    """
+    Classifies a type as either a tensor or a sequence of tensors. These are the only types supported by the MLP/RNN.
+    """
+    if isinstance(typ, ListType):
+        assert isinstance(
+            typ.element_type, TensorType
+        ), f"Expected a list of tensors, but received {render_type(typ)}"
+        return "sequence", typ.element_type.shape
+    if isinstance(typ, TensorType):
+        return "tensor", typ.shape
+    raise ValueError(
+        f"Expected a tensor or a list of tensors, but received {render_type(typ)}"
+    )
+
+
+class GenericMLPRNNNeuralHoleFiller(NeuralHoleFiller):
+    def __init__(self, hidden_size):
+        self.hidden_size = hidden_size
+
+    def initialize_module(
+        self, type_with_environment: TypeWithEnvironment
+    ) -> nn.Module | None:
+
+        typ = type_with_environment.typ
+        input_types = []
+        if isinstance(typ, ArrowType):
+            input_types = list(typ.input_type)
+            typ = typ.output_type
+
+        input_types += [
+            type_with_environment.env[x] for x in range(len(type_with_environment.env))
+        ]
+        return GenericMLPRNNModule(
+            hidden_size=self.hidden_size, input_types=input_types, output_type=typ
+        )
+
+
+class GenericMLPRNNModule(nn.Module):
+
+    def __init__(
+        self,
+        hidden_size,
+        input_types,
+        output_type,
+        dropout: float = 0.0,
+        bias: bool = True,
+        nonlinearity: str = "LeakyReLU",
+        loss: str = "MSELoss",
+    ):
+        super().__init__()
+        self.hidden_size = hidden_size
+
+        self.input_types = input_types
+        self.output_type = output_type
+
+        self.input_classifications = [_classify_type(x) for x in input_types]
+        self.output_classification = _classify_type(output_type)
+
+        input_projections = []
+        for _, shape in self.input_classifications:
+            input_projections.append(nn.Linear(prod(shape), self.hidden_size))
+        self.input_projections = nn.ModuleList(input_projections)
+        self.output_projection = nn.Linear(
+            self.hidden_size, prod(self.output_classification[1])
+        )
+        self.internal_module_type, self.internal_module = _internal_module(
+            self, hidden_size, dropout, bias, nonlinearity, loss
+        )
+
+    def forward(self, *inputs, environment: Tuple[TypeAnnotatedObject, ...]):
+        inputs = list(inputs) + [x.object_value for x in environment]
+        type_shape, output_shape = infer_output_shape(
+            self.input_types, [x.shape for x in inputs], self.output_type
+        )
+        inputs = [
+            proj(type_shape.reshape_to_nlc(x))
+            for proj, x in zip(self.input_projections, inputs)
+        ]
+        input_stacked = sum(inputs)
+        if self.internal_module_type == "mlp":
+            assert input_stacked.shape[1] == 1
+            input_stacked = input_stacked.squeeze(1)
+            output = self.internal_module(input_stacked, environment=environment)
+        elif self.internal_module_type == "rnn":
+            output = self.internal_module(input_stacked, environment=environment)
+        else:
+            raise ValueError(
+                f"Unknown internal module type: {self.internal_module_type}"
+            )
+        output = self.output_projection(output)
+        output = type_shape.unsquash_batch_axis(output)
+        assert output.shape == output_shape
+        return output
+
+
+def _internal_module(self, hidden_size, dropout, bias, nonlinearity, loss):
+    input_seq = any(
+        input_classification[0] == "sequence"
+        for input_classification in self.input_classifications
+    )
+    output_seq = self.output_classification[0] == "sequence"
+
+    assert not (
+        not input_seq and output_seq
+    ), "Cannot have sequence output without sequence input"
+
+    if input_seq:
+        config = RNNConfig(
+            model_name="rnn",
+            input_size=hidden_size,
+            output_size=hidden_size,
+            hidden_size=hidden_size,
+        )
+        return "rnn", Seq2SeqRNN(config) if output_seq else Seq2ClassRNN(config)
+
+    config = MLPConfig(
+        model_name="mlp",
+        input_size=hidden_size,
+        output_size=hidden_size,
+        hidden_size=hidden_size,
+        dropout=dropout,
+        bias=bias,
+        nonlinearity=nonlinearity,
+        loss=loss,
+    )
+    return "mlp", MLP(config)

--- a/neurosym/examples/near/models/generic_mlp_rnn.py
+++ b/neurosym/examples/near/models/generic_mlp_rnn.py
@@ -77,7 +77,7 @@ class GenericMLPRNNNeuralHoleFiller(NeuralHoleFiller):
         ):
             # If the output is a sequence, but none of the inputs are sequences, return None.
             return None
-        return GenericMLPRNNModule(
+        return _GenericMLPRNNModule(
             hidden_size=self.hidden_size,
             input_types=input_types,
             output_type=typ,
@@ -86,7 +86,7 @@ class GenericMLPRNNNeuralHoleFiller(NeuralHoleFiller):
         )
 
 
-class GenericMLPRNNModule(nn.Module):
+class _GenericMLPRNNModule(nn.Module):
 
     def __init__(
         self,

--- a/neurosym/types/type_shape.py
+++ b/neurosym/types/type_shape.py
@@ -1,5 +1,6 @@
 import itertools
 from dataclasses import dataclass
+from math import prod
 from typing import Tuple, Union
 
 from neurosym.types.type_string_repr import render_type
@@ -91,6 +92,33 @@ class TypeShape:
         :return: The number of batch and sequence axes.
         """
         return len(self.batch_size) + len(self.sequence_lengths)
+
+    def squash_batch_axis(self, tensor):
+        """
+        Reshape a given Tensor with this TypeShape to one with a single batch axis.
+        """
+        assert self.batch_size == tensor.shape[: len(self.batch_size)]
+        return tensor.view((-1, *tensor.shape[len(self.batch_size) :]))
+
+    def unsquash_batch_axis(self, tensor):
+        """
+        Reshape a given Tensor with this TypeShape to one with the original batch axis.
+        """
+        return tensor.view((*self.batch_size, *tensor.shape[1:]))
+
+    def reshape_to_nlc(self, tensor):
+        """
+        Reshape a given Tensor with this TypeShape to one of the form (N, L, *C).
+        Requires 0-1 sequence axes.
+        """
+        assert (
+            len(self.sequence_lengths) <= 1
+        ), "Can only reshape tensors to NLC if they have 0-1 sequence axes"
+        tensor_shape = tensor.shape[self.num_batch_and_sequence_axes :]
+        tensor = self.squash_batch_axis(tensor)
+        if not self.sequence_lengths:
+            tensor = tensor.view((tensor.shape[0], 1, *tensor_shape))
+        return tensor
 
 
 def compute_type_shape(typ: Type, shape: Tuple[int, ...]) -> TypeShape:

--- a/neurosym/types/type_shape.py
+++ b/neurosym/types/type_shape.py
@@ -1,6 +1,5 @@
 import itertools
 from dataclasses import dataclass
-from math import prod
 from typing import Tuple, Union
 
 from neurosym.types.type_string_repr import render_type

--- a/neurosym/types/type_with_environment.py
+++ b/neurosym/types/type_with_environment.py
@@ -115,6 +115,12 @@ class Environment:
             sorted((i, render_type(typ)) for i, typ in self._elements.items())
         )
 
+    def __getitem__(self, index):
+        """
+        Get the type at the given index.
+        """
+        return self._elements[index]
+
 
 @dataclass(frozen=True, eq=True)
 class PermissiveEnvironmment:

--- a/tests/near/test_heuristic_used.py
+++ b/tests/near/test_heuristic_used.py
@@ -8,6 +8,7 @@ import unittest
 
 import neurosym as ns
 from neurosym.examples import near
+from neurosym.examples.near.models.generic_mlp_rnn import GenericMLPRNNNeuralHoleFiller
 
 
 class TestNeuralModels(unittest.TestCase):
@@ -70,6 +71,22 @@ class TestNeuralModels(unittest.TestCase):
             self.compute_variable_soln,
         )
 
+    def test_combinator_dsl_works_with_generic(self):
+        self.assertNearReturns(
+            5,
+            near.debug_nested_dsl.get_combinator_dsl,
+            self.generic_rnn_mlp_modules,
+            self.compute_combinator_soln,
+        )
+
+    def test_variable_dsl_works_with_generic(self):
+        self.assertNearReturns(
+            10,
+            near.debug_nested_dsl.get_variable_dsl,
+            self.generic_rnn_mlp_modules,
+            self.compute_variable_soln,
+        )
+
     def compute_combinator_soln(self, nesting):
         expected = ns.SExpression("terminal", ())
         for i in range(2, nesting + 1):
@@ -101,6 +118,10 @@ class TestNeuralModels(unittest.TestCase):
                 num_head=4,
             ),
         )
+
+    def generic_rnn_mlp_modules(self, nesting):
+        del nesting
+        return GenericMLPRNNNeuralHoleFiller(16)
 
     def assertNearReturns(
         self, nesting, dsl_fn, neural_hole_filler, expected, **kwargs

--- a/tests/near/test_heuristic_used.py
+++ b/tests/near/test_heuristic_used.py
@@ -8,7 +8,6 @@ import unittest
 
 import neurosym as ns
 from neurosym.examples import near
-from neurosym.examples.near.models.generic_mlp_rnn import GenericMLPRNNNeuralHoleFiller
 
 
 class TestNeuralModels(unittest.TestCase):
@@ -121,7 +120,7 @@ class TestNeuralModels(unittest.TestCase):
 
     def generic_rnn_mlp_modules(self, nesting):
         del nesting
-        return GenericMLPRNNNeuralHoleFiller(16)
+        return near.GenericMLPRNNNeuralHoleFiller(16)
 
     def assertNearReturns(
         self, nesting, dsl_fn, neural_hole_filler, expected, **kwargs


### PR DESCRIPTION
Trying 10x iterations of `tests/near/test_heuristic_used.py::TestNeuralModels::test_variable_dsl_works_with_*`

Transformer: `4 failed, 6 passed, 54 warnings in 306.36s (0:05:06)`
Generic MLP/RNN: `10 passed, 20 warnings in 49.99s`

This is both much faster (6x faster) and more reliable (probably just because it requires less training)