### PR TITLE
jump ahead in graph

### DIFF
--- a/neurosym/examples/near/search_graph.py
+++ b/neurosym/examples/near/search_graph.py
@@ -102,6 +102,7 @@ def near_graph(
         is_goal,
         NoMetadataComputer(),
         cost,
+        skip_ahead=True,
     )
     graph = FilterUnexpandableNodes(graph, max_depth=max_depth)
     graph = LimitEdgesGraph(graph, max_num_edges)

--- a/neurosym/search_graph/dsl_search_graph.py
+++ b/neurosym/search_graph/dsl_search_graph.py
@@ -2,7 +2,6 @@ import itertools
 from types import NoneType
 from typing import Callable
 
-from neurosym.programs.s_expression_render import render_s_expression
 from neurosym.search_graph.dsl_search_node import DSLSearchNode
 from neurosym.search_graph.metadata_computer import MetadataComputer
 from neurosym.types.type_with_environment import Environment, TypeWithEnvironment
@@ -99,7 +98,6 @@ class DSLSearchGraph(SearchGraph[SExpression]):
             # More than one expansion, so return the node as is
             return node
         except StopIteration:
-            print("skipping", render_s_expression(node.program))
             # Exactly one expansion, so try to expand it further
             return self._maximally_expanded_node(first_expansion)
 

--- a/neurosym/search_graph/dsl_search_graph.py
+++ b/neurosym/search_graph/dsl_search_graph.py
@@ -25,6 +25,10 @@ class DSLSearchGraph(SearchGraph[SExpression]):
     :param test_predicate: Predicate for goal nodes
     :param metadata_computer: Computer for metadata for nodes
     :param compute_cost: Function to compute the cost of a node
+    :param skip_ahead: Whether to skip ahead in the search graph whenever
+        a node coming up has only one possible expansion. This can be useful
+        when the cost of whatever downstream task you have for a partial
+        node is more expensive than the cost of expanding it (possibly) twice.
     """
 
     def __init__(
@@ -35,6 +39,7 @@ class DSLSearchGraph(SearchGraph[SExpression]):
         test_predicate: Callable[[SExpression], bool],
         metadata_computer: MetadataComputer,
         compute_cost: Callable[[DSLSearchNode], float] | NoneType = None,
+        skip_ahead=False,
     ):
         self.dsl = dsl
         self.target_type = target_type
@@ -42,6 +47,7 @@ class DSLSearchGraph(SearchGraph[SExpression]):
         self.test_predicate = test_predicate
         self.metadata_computer = metadata_computer
         self.compute_cost = compute_cost
+        self.skip_ahead = skip_ahead
 
     def initial_node(self):
         return DSLSearchNode(
@@ -50,6 +56,12 @@ class DSLSearchGraph(SearchGraph[SExpression]):
         )
 
     def expand_node(self, node):
+        if not self.skip_ahead:
+            return self._direct_expand_node(node)
+        for expanded_node in self._direct_expand_node(node):
+            yield self._maximally_expanded_node(expanded_node)
+
+    def _direct_expand_node(self, node):
         hole_sets = self.hole_set_chooser.choose_hole_sets(node.program)
         relevant_holes = sorted(set(h for hs in hole_sets for h in hs))
         # relevant_productions[hole_idx] : list of expansions for holes[hole_idx]
@@ -69,6 +81,24 @@ class DSLSearchGraph(SearchGraph[SExpression]):
                     expanded_program,
                     self.metadata_computer.for_expanded_node(node, expanded_program),
                 )
+
+    def _maximally_expanded_node(self, node):
+        if self.is_goal_node(node):
+            # always return goal nodes
+            return node
+        expansions = self._direct_expand_node(node)
+        try:
+            first_expansion = next(expansions)
+        except StopIteration:
+            # No expansions, so return the node as is
+            return node
+        try:
+            next(expansions)
+            # More than one expansion, so return the node as is
+            return node
+        except StopIteration:
+            # Exactly one expansion, so try to expand it further
+            return self._maximally_expanded_node(first_expansion)
 
     def is_goal_node(self, node):
         if any(True for _ in _all_holes(node.program)):

--- a/neurosym/search_graph/dsl_search_graph.py
+++ b/neurosym/search_graph/dsl_search_graph.py
@@ -2,6 +2,7 @@ import itertools
 from types import NoneType
 from typing import Callable
 
+from neurosym.programs.s_expression_render import render_s_expression
 from neurosym.search_graph.dsl_search_node import DSLSearchNode
 from neurosym.search_graph.metadata_computer import MetadataComputer
 from neurosym.types.type_with_environment import Environment, TypeWithEnvironment
@@ -98,6 +99,7 @@ class DSLSearchGraph(SearchGraph[SExpression]):
             # More than one expansion, so return the node as is
             return node
         except StopIteration:
+            print("skipping", render_s_expression(node.program))
             # Exactly one expansion, so try to expand it further
             return self._maximally_expanded_node(first_expansion)
 

--- a/neurosym/search_graph/dsl_search_graph.py
+++ b/neurosym/search_graph/dsl_search_graph.py
@@ -59,7 +59,7 @@ class DSLSearchGraph(SearchGraph[SExpression]):
         if not self.skip_ahead:
             return self._direct_expand_node(node)
         for expanded_node in self._direct_expand_node(node):
-            yield self._maximally_expanded_node(expanded_node)
+            return self._maximally_expanded_node(expanded_node)
 
     def _direct_expand_node(self, node):
         hole_sets = self.hole_set_chooser.choose_hole_sets(node.program)

--- a/neurosym/search_graph/dsl_search_graph.py
+++ b/neurosym/search_graph/dsl_search_graph.py
@@ -56,10 +56,11 @@ class DSLSearchGraph(SearchGraph[SExpression]):
         )
 
     def expand_node(self, node):
+        assert isinstance(node, DSLSearchNode)
         if not self.skip_ahead:
-            return self._direct_expand_node(node)
+            yield from self._direct_expand_node(node)
         for expanded_node in self._direct_expand_node(node):
-            return self._maximally_expanded_node(expanded_node)
+            yield self._maximally_expanded_node(expanded_node)
 
     def _direct_expand_node(self, node):
         hole_sets = self.hole_set_chooser.choose_hole_sets(node.program)

--- a/tests/near/test_heuristic_used.py
+++ b/tests/near/test_heuristic_used.py
@@ -17,7 +17,7 @@ class TestNeuralModels(unittest.TestCase):
             6,
             near.debug_nested_dsl.get_combinator_dsl,
             near.DoNothingNeuralHoleFiller(),
-            "No results",
+            re.compile("No results|.*wrong.*")
         )
 
     def test_no_heuristic_combinator_works_more_time(self):
@@ -34,7 +34,7 @@ class TestNeuralModels(unittest.TestCase):
             6,
             near.debug_nested_dsl.get_variable_dsl,
             near.DoNothingNeuralHoleFiller(),
-            "No results",
+            re.compile("No results|.*wrong.*")
         )
 
     def test_no_heuristic_variables_works_more_time(self):

--- a/tests/near/test_heuristic_used.py
+++ b/tests/near/test_heuristic_used.py
@@ -17,7 +17,7 @@ class TestNeuralModels(unittest.TestCase):
             6,
             near.debug_nested_dsl.get_combinator_dsl,
             near.DoNothingNeuralHoleFiller(),
-            re.compile("No results|.*wrong.*")
+            re.compile("No results|.*wrong.*"),
         )
 
     def test_no_heuristic_combinator_works_more_time(self):
@@ -34,7 +34,7 @@ class TestNeuralModels(unittest.TestCase):
             6,
             near.debug_nested_dsl.get_variable_dsl,
             near.DoNothingNeuralHoleFiller(),
-            re.compile("No results|.*wrong.*")
+            re.compile("No results|.*wrong.*"),
         )
 
     def test_no_heuristic_variables_works_more_time(self):

--- a/tests/near/test_piecewise_linear.py
+++ b/tests/near/test_piecewise_linear.py
@@ -45,6 +45,12 @@ def inject_linear_replacements(dslf):
         dict(aff=lambda: nn.Linear(1, 1)),
     )
     dslf.parameterized(
+        "aff_y",
+        "{f, 2} -> {f, 1}",
+        lambda x, aff: aff(x[:, 1][:, None]),
+        dict(aff=lambda: nn.Linear(1, 1)),
+    )
+    dslf.parameterized(
         "aff_xplusy",
         "{f, 2} -> {f, 1}",
         lambda xy, aff: aff(xy[:, 0][:, None] + xy[:, 1][:, None]),
@@ -138,7 +144,7 @@ class TestPiecewiseLinear(unittest.TestCase):
 
     def search(self, g, count=3):
 
-        iterator = ns.search.bounded_astar(g, max_depth=10000, max_iterations=1000)
+        iterator = ns.search.bounded_astar(g, max_depth=10000, max_iterations=100)
 
         return list(itertools.islice(iterator, count))
 


### PR DESCRIPTION
This is an optimization improvement. Changes to the tests exist purely because this makes some previous "this doesn't work" tests work by speeding up the algorithm :sob: 


## Timing Test

Running `pytest tests/near/test_bouncing_ball.py`

On main: 

198.68s 196.67s 205.27s
Mean: 200s

On jump-ahead-in-graph:

179.07s 179.08s 176.51s

Mean: 178s

11% drop in time taken
