### PR TITLE
Fix type-variable capture when composing polymorphic productions

### DIFF
--- a/neurosym/types/type_signature.py
+++ b/neurosym/types/type_signature.py
@@ -3,15 +3,78 @@ Type signatures are used to represent the types of functions in the
 DSL.
 """
 
+import itertools
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import List, Union
 
 from frozendict import frozendict
 from torch import NoneType
 
-from neurosym.types.type import ArrowType, Type, TypeVariable, UnificationError
+from neurosym.types.type import (
+    ArrowType,
+    GenericTypeVariable,
+    Type,
+    TypeVariable,
+    UnificationError,
+)
 from neurosym.types.type_with_environment import StrictEnvironment, TypeWithEnvironment
+
+_fresh_type_variable_counter = itertools.count()
+
+
+def _instantiate_type_scheme(types: List[Type]) -> List[Type]:
+    """Rename every type variable in ``types`` to a globally-fresh name,
+    consistently across all the given types.
+
+    This implements let-polymorphism: each use of a polymorphic production is an
+    independent instance of its type scheme, so its variables must not be
+    conflated with identically-named variables coming from sibling subterms. For
+    example, ``index :: (i, [#T]) -> #T`` and ``++ :: ([#T], [#T]) -> [#T]`` each
+    declare a variable literally named ``#T``, but the two are unrelated. Without
+    fresh instantiation, composing them (``(++ (index 0 empty) empty)``) forces
+    the single shared ``#T`` into contradictory bindings and unification wrongly
+    fails.
+
+    Variable subclasses (e.g. filtered variables) and their attributes are
+    preserved.
+    """
+    subst = {}
+    for typ in types:
+        for node in typ.walk_type_nodes():
+            if isinstance(node, GenericTypeVariable) and node.name not in subst:
+                fresh_name = f"_fresh_{next(_fresh_type_variable_counter)}"
+                subst[node.name] = replace(node, name=fresh_name)
+    if not subst:
+        return list(types)
+    return [typ.subst_type_vars(subst) for typ in types]
+
+
+def _unify_sequentially(pairs) -> dict:
+    """Unify a sequence of ``(expected, actual)`` type pairs, threading a single
+    substitution through and composing it left to right.
+
+    Applying the accumulated substitution to each pair before unifying it keeps
+    the accumulated substitution's domain disjoint from each new binding's
+    domain, so composition reduces to "apply the new bindings to the old ones,
+    then take the union". This is what lets a variable that is constrained by two
+    different arguments (e.g. both arguments of ``++``) be unified transitively,
+    rather than reported as a spurious conflict.
+
+    :raises UnificationError: if the pairs cannot be unified (including a failed
+        occurs check).
+    """
+    subst = {}
+    for expected, actual in pairs:
+        new = expected.subst_type_vars(subst).unify(actual.subst_type_vars(subst))
+        for name, value in new.items():
+            if name in value.get_type_vars() and not (
+                isinstance(value, GenericTypeVariable) and value.name == name
+            ):
+                raise UnificationError(f"occurs check failed: {name} in {value}")
+        subst = {name: value.subst_type_vars(new) for name, value in subst.items()}
+        subst.update(new)
+    return subst
 
 
 class TypeSignature(ABC):
@@ -111,16 +174,14 @@ class FunctionTypeSignature(TypeSignature):
     ) -> Union[TypeWithEnvironment, NoneType]:
         types = [x.typ for x in twes]
         envs = [x.env for x in twes]
-        mapping = {}
+        # Instantiate this signature's type scheme with fresh variables so its
+        # polymorphic variables are independent of identically-named variables in
+        # the argument types (see _instantiate_type_scheme).
+        *arguments, return_type = _instantiate_type_scheme(
+            list(self.arguments) + [self.return_type]
+        )
         try:
-            for t1, t2 in zip(self.arguments, types):
-                for_arg = t1.unify(t2)
-                for k, v in for_arg.items():
-                    if k in mapping:
-                        if mapping[k] != v:
-                            return None
-                    else:
-                        mapping[k] = v
+            mapping = _unify_sequentially(zip(arguments, types))
         except UnificationError:
             return None
         # Apply substitution to each child env before merging, so that
@@ -128,7 +189,7 @@ class FunctionTypeSignature(TypeSignature):
         if mapping:
             envs = [env.subst_type_vars(mapping) for env in envs]
         env = StrictEnvironment.merge_all(*envs)
-        return TypeWithEnvironment(self.return_type.subst_type_vars(mapping), env)
+        return TypeWithEnvironment(return_type.subst_type_vars(mapping), env)
 
     def arity(self) -> int:
         return len(self.arguments)

--- a/neurosym/types/type_signature.py
+++ b/neurosym/types/type_signature.py
@@ -24,17 +24,9 @@ _fresh_type_variable_counter = itertools.count()
 
 
 def _instantiate_type_scheme(types: List[Type]) -> List[Type]:
-    """Rename every type variable in ``types`` to a globally-fresh name,
-    consistently across all the given types.
-
-    This implements let-polymorphism: each use of a polymorphic production is an
-    independent instance of its type scheme, so its variables must not be
-    conflated with identically-named variables coming from sibling subterms. For
-    example, ``index :: (i, [#T]) -> #T`` and ``++ :: ([#T], [#T]) -> [#T]`` each
-    declare a variable literally named ``#T``, but the two are unrelated. Without
-    fresh instantiation, composing them (``(++ (index 0 empty) empty)``) forces
-    the single shared ``#T`` into contradictory bindings and unification wrongly
-    fails.
+    """
+    Freshen all type variables in the given types, returning a new list of types
+    with the same structure but with fresh type variables.
 
     Variable subclasses (e.g. filtered variables) and their attributes are
     preserved.
@@ -45,21 +37,15 @@ def _instantiate_type_scheme(types: List[Type]) -> List[Type]:
             if isinstance(node, GenericTypeVariable) and node.name not in subst:
                 fresh_name = f"_fresh_{next(_fresh_type_variable_counter)}"
                 subst[node.name] = replace(node, name=fresh_name)
-    if not subst:
-        return list(types)
     return [typ.subst_type_vars(subst) for typ in types]
 
 
 def _unify_sequentially(pairs) -> dict:
-    """Unify a sequence of ``(expected, actual)`` type pairs, threading a single
-    substitution through and composing it left to right.
-
-    Applying the accumulated substitution to each pair before unifying it keeps
-    the accumulated substitution's domain disjoint from each new binding's
-    domain, so composition reduces to "apply the new bindings to the old ones,
-    then take the union". This is what lets a variable that is constrained by two
-    different arguments (e.g. both arguments of ``++``) be unified transitively,
-    rather than reported as a spurious conflict.
+    """
+    Unify a sequence of pairs of types, returning a substitution mapping from type
+    variable names to types. The pairs are unified in order, and the accumulated
+    substitution is applied to each pair before unifying it, allowing for
+    transitive unification of type variables.
 
     :raises UnificationError: if the pairs cannot be unified (including a failed
         occurs check).
@@ -174,9 +160,6 @@ class FunctionTypeSignature(TypeSignature):
     ) -> Union[TypeWithEnvironment, NoneType]:
         types = [x.typ for x in twes]
         envs = [x.env for x in twes]
-        # Instantiate this signature's type scheme with fresh variables so its
-        # polymorphic variables are independent of identically-named variables in
-        # the argument types (see _instantiate_type_scheme).
         *arguments, return_type = _instantiate_type_scheme(
             list(self.arguments) + [self.return_type]
         )

--- a/tests/type/compute_type_polymorphism_test.py
+++ b/tests/type/compute_type_polymorphism_test.py
@@ -1,0 +1,93 @@
+import unittest
+
+import neurosym as ns
+
+
+def _polymorphic_list_dsl():
+    """A tiny polymorphic DSL mirroring the DreamCoder list primitives that
+    exposed the type-variable-capture bug: ``index``, ``++``, ``empty``,
+    ``singleton``. Each polymorphic production declares a variable literally
+    named ``#T``.
+    """
+    dslf = ns.DSLFactory(max_overall_depth=6)
+    dslf.production("0", "() -> i", lambda: 0)
+    dslf.production("empty", "() -> [#T]", lambda: [])
+    dslf.production("singleton", "#T -> [#T]", lambda x: [x])
+    dslf.production("++", "([#T], [#T]) -> [#T]", lambda a, b: a + b)
+    dslf.production("index", "(i, [#T]) -> #T", lambda i, xs: xs[i])
+    dslf.prune_to("[i]", "i")
+    return dslf.finalize()
+
+
+def _canonical_render(type_with_env):
+    """Render a computed type with its type variables canonicalized to ``#t0``,
+    ``#t1``, ... in order of first appearance, so assertions do not depend on the
+    (globally-unique, intentionally non-deterministic) fresh variable names."""
+    typ = type_with_env.typ
+    subst = {}
+    for node in typ.walk_type_nodes():
+        if isinstance(node, ns.TypeVariable) and node.name not in subst:
+            subst[node.name] = ns.TypeVariable(f"t{len(subst)}")
+    return ns.render_type(typ.subst_type_vars(subst))
+
+
+class TestPolymorphicComposition(unittest.TestCase):
+    """Regression tests for type-variable capture across production instances.
+
+    Every polymorphic production in a DSL may reuse the same variable name (here
+    ``#T``), but each *use* of a production is an independent instance of its
+    type scheme. Composing two such productions must not conflate their
+    variables. See ``FunctionTypeSignature.unify_arguments``.
+    """
+
+    def setUp(self):
+        self.dsl = _polymorphic_list_dsl()
+
+    def _type(self, program):
+        return self.dsl.compute_type(ns.parse_s_expression(program))
+
+    def test_regression_baselines_still_work(self):
+        # Both arguments of `++` share a type variable; concatenating two empty
+        # lists must still type-check (this worked before the fix, by the
+        # accident of shared variable names, and must keep working).
+        self.assertEqual(
+            _canonical_render(self._type("(++ (empty) (empty))")), "[#t0]"
+        )
+        # `index` returns an element -- a bare type variable.
+        self.assertEqual(_canonical_render(self._type("(index (0) (empty))")), "#t0")
+
+    def test_element_flows_into_list_position(self):
+        # `(++ (index 0 empty) empty)`: `index` returns an element whose type is
+        # forced to be a list because it is an argument to `++`. This is well
+        # typed -- `index`'s element type unifies with `[#t]` -- and DreamCoder
+        # infers `int -> list(t)` for the enclosing abstraction. Before fresh
+        # instantiation of each production's type scheme, the single shared `#T`
+        # produced a spurious unification conflict and this returned None.
+        result = self._type("(++ (index (0) (empty)) (empty))")
+        self.assertIsNotNone(result)
+        self.assertEqual(_canonical_render(result), "[#t0]")
+        self.assertIsInstance(result.typ, ns.ListType)
+        self.assertIsInstance(result.typ.element_type, ns.TypeVariable)
+
+    def test_nested_polymorphic_application(self):
+        # `(index 0 (index 0 empty))`: the inner `index` result is forced to be a
+        # list by the outer `index`, whose result is a single element. Before the
+        # fix the shared `#T` collapsed this to `[#T]` (an un-occurs-checked
+        # cyclic `#T = [#T]` binding); it should be a bare element.
+        result = self._type("(index (0) (index (0) (empty)))")
+        self.assertEqual(_canonical_render(result), "#t0")
+        self.assertIsInstance(result.typ, ns.TypeVariable)
+
+    def test_singleton_baseline_matches(self):
+        # Wrapping the element in a singleton first is the well-typed way to
+        # write the same thing, and yields the same type.
+        self.assertEqual(
+            _canonical_render(
+                self._type("(++ (singleton (index (0) (empty))) (empty))")
+            ),
+            "[#t0]",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/type/compute_type_polymorphism_test.py
+++ b/tests/type/compute_type_polymorphism_test.py
@@ -50,9 +50,7 @@ class TestPolymorphicComposition(unittest.TestCase):
         # Both arguments of `++` share a type variable; concatenating two empty
         # lists must still type-check (this worked before the fix, by the
         # accident of shared variable names, and must keep working).
-        self.assertEqual(
-            _canonical_render(self._type("(++ (empty) (empty))")), "[#t0]"
-        )
+        self.assertEqual(_canonical_render(self._type("(++ (empty) (empty))")), "[#t0]")
         # `index` returns an element -- a bare type variable.
         self.assertEqual(_canonical_render(self._type("(index (0) (empty))")), "#t0")
 


### PR DESCRIPTION
FunctionTypeSignature.unify_arguments used each production's declared type variables verbatim and merged per-argument substitutions with a naive "same key + different value => fail" rule. This had two defects:

1. No per-use instantiation: every polymorphic production reuses the same variable name (e.g. `#T`), so the `#T` of `index :: (i, [#T]) -> #T` and the `#T` of `++ :: ([#T], [#T]) -> [#T]` were treated as one variable, forcing the contradictory constraint `#T = [#T]`.
2. No substitution composition: a variable constrained by two arguments could not be unified transitively; the second binding was reported as a conflict.

As a result `compute_type` returned None for the well-typed program `(++ (index 0 empty) empty)` (DreamCoder's Hindley-Milner infers `int -> list(t)`), and `(index 0 (index 0 empty))` silently produced `[#T]` from an un-occurs-checked cyclic binding.

Instantiate each production's type scheme with fresh variables at every use (let-polymorphism), preserving variable subclasses/filters, and compose the argument substitutions properly (thread one substitution, applying it before each unification) with an occurs check. Only unify_arguments changes; unify_return and return_type_template are untouched.